### PR TITLE
Add js and jsx to source exts to avoid js imports from breaking

### DIFF
--- a/docs/multiple-transformers.md
+++ b/docs/multiple-transformers.md
@@ -25,8 +25,8 @@ module.exports = {
     return require.resolve("./transformer.js");
   },
   getSourceExts() {
-    return ["scss", "sass", "css"];
-  },
+    return ["js", "jsx", "scss", "sass", "css"];
+  }
 };
 ```
 

--- a/docs/setup-css.md
+++ b/docs/setup-css.md
@@ -66,7 +66,7 @@ module.exports = {
     return require.resolve("react-native-css-transformer");
   },
   getSourceExts() {
-    return ["css"];
+    return ["js", "jsx", "css"];
   }
 };
 ```
@@ -77,7 +77,7 @@ module.exports = {
 {
   "expo": {
     "packagerOpts": {
-      "sourceExts": ["css"],
+      "sourceExts": ["js", "jsx", "css"],
       "transformer": "node_modules/react-native-css-transformer/index.js"
     }
   }

--- a/docs/setup-less.md
+++ b/docs/setup-less.md
@@ -66,7 +66,7 @@ module.exports = {
     return require.resolve("react-native-less-transformer");
   },
   getSourceExts() {
-    return ["less"];
+    return ["js", "jsx", "less"];
   }
 };
 ```
@@ -77,7 +77,7 @@ module.exports = {
 {
   "expo": {
     "packagerOpts": {
-      "sourceExts": ["less"],
+      "sourceExts": ["js", "jsx", "less"],
       "transformer": "node_modules/react-native-less-transformer/index.js"
     }
   }

--- a/docs/setup-media-queries.md
+++ b/docs/setup-media-queries.md
@@ -66,9 +66,22 @@ module.exports = {
     return require.resolve("react-native-css-transformer");
   },
   getSourceExts() {
-    return ["css"];
-  },
+    return ["js", "jsx", "css"];
+  }
 };
+```
+
+...or if you are using [Expo](https://expo.io/), in `app.json`:
+
+```json
+{
+  "expo": {
+    "packagerOpts": {
+      "sourceExts": ["js", "jsx", "css"],
+      "transformer": "node_modules/react-native-css-transformer/index.js"
+    }
+  }
+}
 ```
 
 ### Step 6: Add some CSS with media queries to your project and use it inside a React component

--- a/docs/setup-postcss.md
+++ b/docs/setup-postcss.md
@@ -72,7 +72,7 @@ module.exports = {
     return require.resolve("./postcss-transformer.js");
   },
   getSourceExts() {
-    return ["css", "pcss"]; // <-- Add other extensions if needed.
+    return ["js", "jsx", "css", "pcss"]; // <-- Add other extensions if needed.
   }
 };
 ```
@@ -83,7 +83,7 @@ module.exports = {
 {
   "expo": {
     "packagerOpts": {
-      "sourceExts": ["css", "pcss"],
+      "sourceExts": ["js", "jsx", "css", "pcss"],
       "transformer": "./postcss-transformer.js"
     }
   }

--- a/docs/setup-sass.md
+++ b/docs/setup-sass.md
@@ -66,7 +66,7 @@ module.exports = {
     return require.resolve("react-native-sass-transformer");
   },
   getSourceExts() {
-    return ["scss", "sass"];
+    return ["js", "jsx", "scss", "sass"];
   }
 };
 ```
@@ -77,7 +77,7 @@ module.exports = {
 {
   "expo": {
     "packagerOpts": {
-      "sourceExts": ["scss", "sass"],
+      "sourceExts": ["js", "jsx", "scss", "sass"],
       "transformer": "node_modules/react-native-sass-transformer/index.js"
     }
   }

--- a/docs/setup-stylus.md
+++ b/docs/setup-stylus.md
@@ -66,7 +66,7 @@ module.exports = {
     return require.resolve("react-native-stylus-transformer");
   },
   getSourceExts() {
-    return ["styl"];
+    return ["js", "jsx", "styl"];
   }
 };
 ```
@@ -77,7 +77,7 @@ module.exports = {
 {
   "expo": {
     "packagerOpts": {
-      "sourceExts": ["styl"],
+      "sourceExts": ["js", "jsx", "styl"],
       "transformer": "node_modules/react-native-stylus-transformer/index.js"
     }
   }


### PR DESCRIPTION
In newest React Native versions a change in the bundler settings causes (with the current docs) React Native to load the CSS file instead of the Javascript file, when you do `import App from "./App";` and you have `App.js` and `App.css` files.

Source:
https://github.com/kristerkari/react-native-sass-transformer/issues/5