### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Style React Native components using CSS, PostCSS, Sass, Less or Stylus.
 
-**Quick links:** **[Features](#features)** • **[Documentation](https://github.com/kristerkari/react-native-css-modules#documentation)** • **[Example](#example)** • **[Development](#development)** • **[FAQ](docs/faq.md#frequently-asked-questions)**
+**Quick links:** **[Features](#features)** • **[Documentation](https://github.com/kristerkari/react-native-css-modules#documentation)** • **[Example Apps](#example-apps)** • **[Development](#development)** • **[FAQ](docs/faq.md#frequently-asked-questions)**
 
 <a href="https://facebook.github.io/react-native/"><img src="images/react-native-logo.png" width="160"></a><img src="images/plus.svg" width="100"><a href="https://github.com/css-modules/css-modules"><img src="images/css-modules-logo.svg" width="170"></a>
 


### PR DESCRIPTION
First of all, thanks for this project, looks great! Would be super interested to see what the current / future version of CSS Modules in React Native + Web can look like, especially with the advent of [`react-strict-dom`](https://twitter.com/dan_abramov2/status/1760245165703184516): https://twitter.com/karlhorky/status/1760369810519859656

Quick PR to fix the link in the readme: I think the heading changed from Example to Example Apps